### PR TITLE
Allow disabling throttling while still notifying subscribers

### DIFF
--- a/lib/nexaas/throttle/middleware.rb
+++ b/lib/nexaas/throttle/middleware.rb
@@ -7,31 +7,34 @@ module Rack
       @configuration ||= Nexaas::Throttle.configuration
     end
 
-    def self.throttled_headers(env)
-      content_type = env["CONTENT_TYPE"]
-      retry_after = (env["rack.attack.match_data"] || {})[:period]
-
-      {
-        "Content-Type" => content_type,
-        "Retry-After" => retry_after.to_s
-      }
-    end
-
     def self.guardian(request)
       Nexaas::Throttle::Guardian.new(request, configuration.request_identifier)
     end
 
-    cache.store = ActiveSupport::Cache::RedisStore.new(configuration.redis_options)
+    def self.throttled?(req)
+      throttled = throttles.any? do |name, throttle|
+        throttle[req]
+      end
+
+      throttled && configuration.throttleable?
+    end
+
+    self.cache.store = ActiveSupport::Cache::RedisStore.new(configuration.redis_options)
     self.throttled_response = lambda do |env|
-      [429, throttled_headers(env), ["Retry later\n"]]
+      headers = {
+        "Content-Type" => (env["CONTENT_TYPE"] || env["Content-Type"]).to_s,
+        "Retry-After" => (env["rack.attack.match_data"] || {})[:period].to_s
+      }
+
+      [429, headers, ["Retry later\n"]]
     end
 
     throttle("nexaas/throttle", limit: configuration.limit, period: configuration.period) do |request|
-      guardian(request).throttle! if configuration.throttleable?
+      guardian(request).throttle!
     end
 
     track("nexaas/track") do |request|
-      configuration.trackable? && guardian(request).track!
+      guardian(request).track! if configuration.trackable?
     end
   end
 end
@@ -87,9 +90,7 @@ module Nexaas
       end
 
       def remaining(limit_data)
-        remaining = limit_data[:limit].to_i - limit_data[:count].to_i
-        remaining = 0 if remaining < 0
-        remaining.to_s
+        (limit_data[:limit].to_i - limit_data[:count].to_i).to_s
       end
     end
   end


### PR DESCRIPTION
Allow disabling throttle mechanism while still notifying subscribers.

When a request is throttled, instrumentation occurs while request is not halted if `configuration.throttle = false`.