### PR TITLE
Ignored User-Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ end
       </pre>
     </td>
   </tr>
+  <tr>
+    <td><code>ignored_user_agents</code></td>
+    <td>Ignores how many User-Agent the application wants, in case of other applications from the same organization.</td>
+    <td><code>nil</code></td>
+  </tr>
 </table>
 
 ### Request Identification
@@ -145,4 +150,3 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/myfree
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
-

--- a/lib/nexaas/throttle/configuration.rb
+++ b/lib/nexaas/throttle/configuration.rb
@@ -37,6 +37,11 @@ module Nexaas
       # @return [Hash]
       attr_reader :redis_options
 
+      # Ignores how many User-Agent the application wants, in case of other applications from the same organization.
+      # Example: ["Google", "Amazons"]
+      # @return [Array]
+      attr_accessor :ignored_user_agents
+
       alias_method :throttleable?, :throttle
       alias_method :trackable?, :track
 
@@ -47,6 +52,7 @@ module Nexaas
         @limit = 60
         @request_identifier = nil
         @redis_options = default_redis_options
+        @ignored_user_agents = nil
       end
 
       def check!

--- a/lib/nexaas/throttle/middleware.rb
+++ b/lib/nexaas/throttle/middleware.rb
@@ -8,7 +8,7 @@ module Rack
     end
 
     def self.guardian(request)
-      Nexaas::Throttle::Guardian.new(request, configuration.request_identifier)
+      Nexaas::Throttle::Guardian.new(request, configuration)
     end
 
     def self.throttled?(req)

--- a/spec/nexaas/throttle/configuration_spec.rb
+++ b/spec/nexaas/throttle/configuration_spec.rb
@@ -32,6 +32,10 @@ describe Nexaas::Throttle::Configuration do
         namespace: "nexaas:throttle"
       )
     end
+
+    it "initializes @ignored_user_agents" do
+      expect(configuration.ignored_user_agents).to be_nil
+    end
   end
 
   describe "#throttleable?" do

--- a/spec/nexaas/throttle/guardian_spec.rb
+++ b/spec/nexaas/throttle/guardian_spec.rb
@@ -4,7 +4,8 @@ describe Nexaas::Throttle::Guardian do
   let(:request) { double("Request", env: {}) }
   let(:request_identifier_klass) { class_double("RequestIdentifier") }
   let(:request_identifier_instance) { double("RequestIdentifier") }
-  let(:guardian) { described_class.new(request, request_identifier_klass) }
+  let(:configuration) { double(request_identifier: request_identifier_klass, ignored_user_agents: nil) }
+  let(:guardian) { described_class.new(request, configuration) }
 
   before do
     allow(request_identifier_klass).to receive(:new).
@@ -14,6 +15,12 @@ describe Nexaas::Throttle::Guardian do
   end
 
   describe "#throttle!" do
+    it "ignored with specific User-Agent request" do
+        allow(request).to receive(:user_agent).and_return("Google")
+        allow(configuration).to receive(:ignored_user_agents).and_return(["Google"])
+        expect(guardian.throttle!).to be_nil
+    end
+
     context "web request" do
       it "returns nil with an asset path" do
         allow(request).to receive(:path).and_return("/assets")
@@ -72,6 +79,12 @@ describe Nexaas::Throttle::Guardian do
   end
 
   describe "#track!" do
+    it "ignored with specific User-Agent request" do
+        allow(request).to receive(:user_agent).and_return("Google")
+        allow(configuration).to receive(:ignored_user_agents).and_return(["Google"])
+        expect(guardian.track!).to be_nil
+    end
+
     context "web request" do
       it "returns nil with an asset path" do
         allow(request).to receive(:path).and_return("/assets")


### PR DESCRIPTION
### Description

Ignores how many User-Agent the application wants, in case of other applications from the same organization.

#### Example: 

Nexaas::Throttle.configure do |config|
  config.throttle = true
  config.track = true
  config.period = 1.minute
  config.limit = 20 # 20 req/min
  config.request_identifier = ApiRequestIdentifier
  config.redis_options = {
    host: ENV["REDIS_HOST"],
    port: ENV["REDIS_PORT"],
    db: ENV["REDIS_DB"]
  }
  config.ignored_user_agents = %w(Google Amazon) # Default: nil
end