### PR TITLE
Stop checking if request is via API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.gem
 *.rbc
+*.swp
 /.config
 /coverage/
 /InstalledFiles

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ end
 `Nexaas::Throttle` doesn't know how to identify a consumer. Some applications might rely on request IP, others on an API TOKEN. You must provide a way of getting an unique token
 that identify a request consumer.
 
+If there is no token, the request will go through and won't be accounted for.
+
 `Nexaas::Throttle` do this by providing a configuration `request_identifier`, a class where your application would keep the logic that identifies a consumer. This class must have the following
 interface:
 

--- a/lib/nexaas/throttle/guardian.rb
+++ b/lib/nexaas/throttle/guardian.rb
@@ -22,7 +22,7 @@ module Nexaas
       attr_reader :request, :token, :ignored_user_agents
 
       def validate
-        return if ignore_user_agents? || assets? || !api? || token.blank?
+        return if ignore_user_agents? || assets? || token.blank?
         request.env["nexaas.token"] = token
         yield if block_given?
       end
@@ -30,11 +30,6 @@ module Nexaas
       def assets?
         path = request.path
         path.match(/\/assets/).present? || path.match(extensions_regexp).present?
-      end
-
-      def api?
-        content_type = (request.media_type || request.env["Content-Type"]).to_s
-        %w(application/json application/xml).include?(content_type)
       end
 
       def extensions_regexp

--- a/lib/nexaas/throttle/version.rb
+++ b/lib/nexaas/throttle/version.rb
@@ -1,5 +1,5 @@
 module Nexaas
   module Throttle
-    VERSION = "1.0.0".freeze
+    VERSION = "2.0.0".freeze
   end
 end

--- a/lib/nexaas/throttle/version.rb
+++ b/lib/nexaas/throttle/version.rb
@@ -1,5 +1,5 @@
 module Nexaas
   module Throttle
-    VERSION = "2.0.0".freeze
+    VERSION = "1.0.0".freeze
   end
 end

--- a/spec/nexaas/throttle/guardian_spec.rb
+++ b/spec/nexaas/throttle/guardian_spec.rb
@@ -16,9 +16,9 @@ describe Nexaas::Throttle::Guardian do
 
   describe "#throttle!" do
     it "ignored with specific User-Agent request" do
-        allow(request).to receive(:user_agent).and_return("Google v1.0")
-        allow(configuration).to receive(:ignored_user_agents).and_return([/[Gg]oogle/])
-        expect(guardian.throttle!).to be_nil
+      allow(request).to receive(:user_agent).and_return("Google v1.0")
+      allow(configuration).to receive(:ignored_user_agents).and_return([/[Gg]oogle/])
+      expect(guardian.throttle!).to be_nil
     end
 
     context "web request" do
@@ -29,12 +29,6 @@ describe Nexaas::Throttle::Guardian do
 
       it "returns nil with an asset related path" do
         allow(request).to receive(:path).and_return("/something/different.js")
-        expect(guardian.throttle!).to be_nil
-      end
-
-      it "returns nil with non api request" do
-        allow(request).to receive(:path).and_return("a/web/request")
-        allow(request).to receive(:media_type).and_return("text/html")
         expect(guardian.throttle!).to be_nil
       end
 
@@ -93,12 +87,6 @@ describe Nexaas::Throttle::Guardian do
 
       it "returns nil with an asset related path" do
         allow(request).to receive(:path).and_return("/something/different.js")
-        expect(guardian.track!).to be_nil
-      end
-
-      it "returns nil with non api request" do
-        allow(request).to receive(:path).and_return("a/web/request")
-        allow(request).to receive(:media_type).and_return("text/html")
         expect(guardian.track!).to be_nil
       end
 

--- a/spec/nexaas/throttle/middleware_spec.rb
+++ b/spec/nexaas/throttle/middleware_spec.rb
@@ -118,13 +118,6 @@ describe Nexaas::Throttle::Middleware do
       end
     end
 
-    context "web" do
-      it "does not throttle web requests" do
-        3.times { get "/hello/world" }
-        expect(last_response.status).not_to eq(429)
-      end
-    end
-
     context "assets" do
       it "does not throttle assets requests paths" do
         3.times { get "/assets/image.png" }
@@ -187,13 +180,6 @@ describe Nexaas::Throttle::Middleware do
           3.times { get "/hello/world", {}, "Content-Type" => "application/xml" }
           expect(tracker).not_to have_received(:inc)
         end
-      end
-    end
-
-    context "web" do
-      it "does not track web requests" do
-        3.times { get "/hello/world" }
-        expect(tracker).not_to have_received(:inc)
       end
     end
 


### PR DESCRIPTION
Version 1.0 only throttles API requests.

For the gem, an API request is a request with a `Content-Type` header with a value of `application/json` or `application/xml`. It's a Web request otherwise.

If a user hits the endpoint `https://potato.com/tomato.json`, the back-end server will identify this request as a JSON request, even though there is no `Content-Type`. This can be exploited with the intent of bypassing the Throttler since it doesn't consider this request an API request.

I think the gem should not care about the request type. The application using the gem should have its own filter and only pass requests that are meant to be throttled.

This PR removes this check and passes the responsibility to the application.