### PR TITLE
Fix asset regex matching

### DIFF
--- a/lib/nexaas/throttle/guardian.rb
+++ b/lib/nexaas/throttle/guardian.rb
@@ -29,13 +29,13 @@ module Nexaas
 
       def assets?
         path = request.path
-        path.match(/\/assets/).present? || path.match(extensions_regexp).present?
+        path.match(%r{/assets}).present? || path.match(extensions_regexp).present?
       end
 
       def extensions_regexp
         @assets_extensions ||= begin
           extensions = %w(css js png jpg gif)
-          /\.(#{extensions.join("|")})/
+          /\.(#{extensions.join("|")})$/
         end
       end
 

--- a/lib/nexaas/throttle/guardian.rb
+++ b/lib/nexaas/throttle/guardian.rb
@@ -34,9 +34,9 @@ module Nexaas
 
       def extensions_regexp
         @assets_extensions ||= begin
-          extensions = %w(css js png jpg gif)
-          /\.(#{extensions.join("|")})$/
-        end
+                                 extensions_group = %w(css js png jpg gif).join("|")
+                                 /\.(#{extensions_group})(\?\S*)?$/
+                               end
       end
 
       def ignore_user_agents?

--- a/spec/nexaas/throttle/guardian_spec.rb
+++ b/spec/nexaas/throttle/guardian_spec.rb
@@ -32,6 +32,21 @@ describe Nexaas::Throttle::Guardian do
         expect(guardian.throttle!).to be_nil
       end
 
+      it "returns nil with an asset related path with a single url parameter" do
+        allow(request).to receive(:path).and_return("/something/different.js?myparam=something")
+        expect(guardian.throttle!).to be_nil
+      end
+
+      it "returns nil with an asset related path with multiple url parameters" do
+        allow(request).to receive(:path).and_return("/something/different.js?myparam=something&foo=bar")
+        expect(guardian.throttle!).to be_nil
+      end
+
+      it "returns nil with an asset related path with simple url parameters" do
+        allow(request).to receive(:path).and_return("/something/different.js?something")
+        expect(guardian.throttle!).to be_nil
+      end
+
       it "does not inject token" do
         allow(request).to receive(:path).and_return("/assets")
         guardian.throttle!
@@ -87,6 +102,21 @@ describe Nexaas::Throttle::Guardian do
 
       it "returns nil with an asset related path" do
         allow(request).to receive(:path).and_return("/something/different.js")
+        expect(guardian.track!).to be_nil
+      end
+
+      it "returns nil with an asset related path with a single url parameter" do
+        allow(request).to receive(:path).and_return("/something/different.js?myparam=something")
+        expect(guardian.track!).to be_nil
+      end
+
+      it "returns nil with an asset related path with multiple url parameters" do
+        allow(request).to receive(:path).and_return("/something/different.js?myparam=something&foo=bar")
+        expect(guardian.track!).to be_nil
+      end
+
+      it "returns nil with an asset related path with a simple url parameter" do
+        allow(request).to receive(:path).and_return("/something/different.js?something")
         expect(guardian.track!).to be_nil
       end
 

--- a/spec/nexaas/throttle/guardian_spec.rb
+++ b/spec/nexaas/throttle/guardian_spec.rb
@@ -41,7 +41,7 @@ describe Nexaas::Throttle::Guardian do
 
     context "json request" do
       before do
-        allow(request).to receive(:path).and_return("a/json/request")
+        allow(request).to receive(:path).and_return("/resource.json")
         allow(request).to receive(:media_type).and_return("application/json")
       end
 
@@ -57,7 +57,7 @@ describe Nexaas::Throttle::Guardian do
 
     context "xml request" do
       before do
-        allow(request).to receive(:path).and_return("a/xml/request")
+        allow(request).to receive(:path).and_return("/resource.xml")
         allow(request).to receive(:media_type).and_return("application/xml")
       end
 
@@ -74,9 +74,9 @@ describe Nexaas::Throttle::Guardian do
 
   describe "#track!" do
     it "ignored with specific User-Agent request" do
-        allow(request).to receive(:user_agent).and_return("Google v1.0")
-        allow(configuration).to receive(:ignored_user_agents).and_return([/[Gg]oogle/])
-        expect(guardian.track!).to be_nil
+      allow(request).to receive(:user_agent).and_return("Google v1.0")
+      allow(configuration).to receive(:ignored_user_agents).and_return([/[Gg]oogle/])
+      expect(guardian.track!).to be_nil
     end
 
     context "web request" do


### PR DESCRIPTION
Due to bad regex, all requests ending with `.json` were being matched as a JS request. Since we ignore asset requests (`.js`, `.css`, etc), `.json` requests were also ignored.

The specs were also not using realistic path formatting so we were completely unaware of the bug.