### PR TITLE
Stop checking for query string in request#path

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Nexaas::Throttle.configure do |config|
     namespace: "nexaas:throttle"
   }
   config.ignored_user_agents = [/[Gg]oogle/, /Amazon/]
+  config.assets_extensions = %w[bmp tiff css js jpg jpeg png gif woff ttf svg]
 end
 ```
 
@@ -96,6 +97,11 @@ end
     <td><code>ignored_user_agents</code></td>
     <td>An array of User Agents that should be ignored by the throttler. Values are regexes that will be matched against the request User-Agent</td>
     <td><code>nil</code></td>
+  </tr>
+  <tr>
+    <td><code>assets_extensions</code></td>
+    <td>An array of file extensions considered to be asset-related.  Values are strings that will be matched against the request path.  Paths that match will be not be throttled</td>
+    <td><code>%w[css js jpg jpeg png gif woff ttf svg]</code></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ end
   </tr>
   <tr>
     <td><code>assets_extensions</code></td>
-    <td>An array of file extensions considered to be asset-related.  Values are strings that will be matched against the request path.  Paths that match will be not be throttled</td>
+    <td>An array of file extensions considered to be asset-related. Values are strings that will be matched against the request path. Paths that match will be not be throttled</td>
     <td><code>%w[css js jpg jpeg png gif woff ttf svg]</code></td>
   </tr>
 </table>

--- a/lib/nexaas/throttle/configuration.rb
+++ b/lib/nexaas/throttle/configuration.rb
@@ -43,6 +43,13 @@ module Nexaas
       # @return [Array]
       attr_accessor :ignored_user_agents
 
+      # An array of file extensions considered to be asset-related.
+      # Values are strings that will be matched against the request path.
+      # Paths that match will be not be throttled.
+      # Example: ["css", "js", "jpeg", "jpg", "png"]
+      # @return [Array]
+      attr_accessor :assets_extensions
+
       alias_method :throttleable?, :throttle
       alias_method :trackable?, :track
 
@@ -54,6 +61,7 @@ module Nexaas
         @request_identifier = nil
         @redis_options = default_redis_options
         @ignored_user_agents = nil
+        @assets_extensions = %w[css js jpg jpeg png gif woff ttf svg]
       end
 
       def check!

--- a/lib/nexaas/throttle/guardian.rb
+++ b/lib/nexaas/throttle/guardian.rb
@@ -22,21 +22,19 @@ module Nexaas
       attr_reader :request, :token, :ignored_user_agents
 
       def validate
-        return if ignore_user_agents? || assets? || token.blank?
+        return if ignore_user_agents? || asset_request? || token.blank?
         request.env["nexaas.token"] = token
         yield if block_given?
       end
 
-      def assets?
+      def asset_request?
         path = request.path
-        path.match(%r{/assets}).present? || path.match(extensions_regexp).present?
+        path.match(%r{/assets}).present? || path.match(assets_extensions_regexp).present?
       end
 
-      def extensions_regexp
-        @assets_extensions ||= begin
-                                 extensions_group = %w(css js png jpg gif).join("|")
-                                 /\.(#{extensions_group})(\?\S*)?$/
-                               end
+      def assets_extensions_regexp
+        extensions_group = %w(css js png jpg gif).join("|")
+        /\.(#{extensions_group})$/
       end
 
       def ignore_user_agents?

--- a/lib/nexaas/throttle/guardian.rb
+++ b/lib/nexaas/throttle/guardian.rb
@@ -33,8 +33,10 @@ module Nexaas
       end
 
       def assets_extensions_regexp
-        extensions_group = %w(css js png jpg gif).join("|")
-        /\.(#{extensions_group})$/
+        @assets_extensions_regexp ||= begin
+                                        extensions_group = %w(css js png jpg gif).join("|")
+                                        /\.(#{extensions_group})$/
+                                      end
       end
 
       def ignore_user_agents?

--- a/lib/nexaas/throttle/guardian.rb
+++ b/lib/nexaas/throttle/guardian.rb
@@ -7,6 +7,7 @@ module Nexaas
         @request = request
         @token = configuration.request_identifier.new(request).token
         @ignored_user_agents = configuration.ignored_user_agents
+        @assets_extensions = configuration.assets_extensions
       end
 
       def throttle!
@@ -19,7 +20,7 @@ module Nexaas
 
       private
 
-      attr_reader :request, :token, :ignored_user_agents
+      attr_reader :request, :token, :ignored_user_agents, :assets_extensions
 
       def validate
         return if ignore_user_agents? || asset_request? || token.blank?
@@ -33,10 +34,8 @@ module Nexaas
       end
 
       def assets_extensions_regexp
-        @assets_extensions_regexp ||= begin
-                                        extensions_group = "css|js|png|jpg|gif"
-                                        /\.(#{extensions_group})$/
-                                      end
+        extensions = assets_extensions.join("|")
+        /\.(#{extensions})$/
       end
 
       def ignore_user_agents?

--- a/lib/nexaas/throttle/guardian.rb
+++ b/lib/nexaas/throttle/guardian.rb
@@ -34,7 +34,7 @@ module Nexaas
 
       def assets_extensions_regexp
         @assets_extensions_regexp ||= begin
-                                        extensions_group = %w(css js png jpg gif).join("|")
+                                        extensions_group = "css|js|png|jpg|gif"
                                         /\.(#{extensions_group})$/
                                       end
       end

--- a/spec/nexaas/throttle/configuration_spec.rb
+++ b/spec/nexaas/throttle/configuration_spec.rb
@@ -36,6 +36,10 @@ describe Nexaas::Throttle::Configuration do
     it "initializes @ignored_user_agents" do
       expect(configuration.ignored_user_agents).to be_nil
     end
+
+    it "initializes @assets_extensions" do
+      expect(configuration.assets_extensions).to eq(%w[css js jpg jpeg png gif woff ttf svg])
+    end
   end
 
   describe "#throttleable?" do

--- a/spec/nexaas/throttle/guardian_spec.rb
+++ b/spec/nexaas/throttle/guardian_spec.rb
@@ -32,18 +32,9 @@ describe Nexaas::Throttle::Guardian do
         expect(guardian.throttle!).to be_nil
       end
 
-      it "returns nil with an asset related path with a single url parameter" do
-        allow(request).to receive(:path).and_return("/something/different.js?myparam=something")
-        expect(guardian.throttle!).to be_nil
-      end
-
-      it "returns nil with an asset related path with multiple url parameters" do
-        allow(request).to receive(:path).and_return("/something/different.js?myparam=something&foo=bar")
-        expect(guardian.throttle!).to be_nil
-      end
-
-      it "returns nil with an asset related path with simple url parameters" do
-        allow(request).to receive(:path).and_return("/something/different.js?something")
+      it "returns nil with an asset related path with a query string" do
+        allow(request).to receive(:query_string).and_return("myparam=something")
+        allow(request).to receive(:path).and_return("/something/different.js")
         expect(guardian.throttle!).to be_nil
       end
 
@@ -105,18 +96,9 @@ describe Nexaas::Throttle::Guardian do
         expect(guardian.track!).to be_nil
       end
 
-      it "returns nil with an asset related path with a single url parameter" do
-        allow(request).to receive(:path).and_return("/something/different.js?myparam=something")
-        expect(guardian.track!).to be_nil
-      end
-
-      it "returns nil with an asset related path with multiple url parameters" do
-        allow(request).to receive(:path).and_return("/something/different.js?myparam=something&foo=bar")
-        expect(guardian.track!).to be_nil
-      end
-
-      it "returns nil with an asset related path with a simple url parameter" do
-        allow(request).to receive(:path).and_return("/something/different.js?something")
+      it "returns nil with an asset related path with a query string" do
+        allow(request).to receive(:query_string).and_return("myparam=something")
+        allow(request).to receive(:path).and_return("/something/different.js")
         expect(guardian.track!).to be_nil
       end
 

--- a/spec/nexaas/throttle/guardian_spec.rb
+++ b/spec/nexaas/throttle/guardian_spec.rb
@@ -4,7 +4,11 @@ describe Nexaas::Throttle::Guardian do
   let(:request) { double("Request", env: {}) }
   let(:request_identifier_klass) { class_double("RequestIdentifier") }
   let(:request_identifier_instance) { double("RequestIdentifier") }
-  let(:configuration) { double(request_identifier: request_identifier_klass, ignored_user_agents: nil) }
+  let(:configuration) do
+    double(request_identifier: request_identifier_klass,
+           ignored_user_agents: nil,
+           assets_extensions: %w[css js jpg png])
+  end
   let(:guardian) { described_class.new(request, configuration) }
 
   before do


### PR DESCRIPTION
In #7 we started checking for query strings in the `#path` of asset requests. This is not necessary, since `#path` **never** returns any query string.